### PR TITLE
Add example of overriding the sandbox property

### DIFF
--- a/custom-external-webpage/README.md
+++ b/custom-external-webpage/README.md
@@ -1,0 +1,8 @@
+# README
+This is an example of a plugin that can be used to present a website using plugins.  If sandbox properties need to be modified, these should be updated in the plugin configuration, as well as the HTML file.  
+
+Note: It's always a good idea to first check if there are reasonable alternatives instead of changing the restrictions, then only remove the minimum restrictions as needed. 
+
+read more here:
+https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox
+https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/General_embedding_technologies#security_concerns

--- a/custom-external-webpage/index.html
+++ b/custom-external-webpage/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <link
+      rel="stylesheet"
+      href="https://www.coursera.org/widget/coursera-connect.css"
+    />
+    <link
+      rel="stylesheet"
+      href="./style.css"
+    />
+  </head>
+  <body>
+    <div class="container">
+    <!-- This is the iframe within the plugin that your website will be loaded in.
+     Modify the sandbox attribute here as needed - note that this needs to be set before the iframe content
+     loads, so this will need to duplicate the sandbox attribute in the configuration. -->
+    <iframe
+      id="custom-url-iframe"
+      width="100%"
+      height="100%"
+      src=""
+      sandbox="allow-scripts allow-same-origin allow-popups allow-downloads"
+    ></iframe>
+ 
+  </div>
+
+    <script src="https://www.coursera.org/widget/coursera-widget-connect-v0.js"></script>
+    <script src="./initializePlugin.js"></script>
+  </body>
+</html>

--- a/custom-external-webpage/initializePlugin.js
+++ b/custom-external-webpage/initializePlugin.js
@@ -1,0 +1,30 @@
+
+// initialize the plugin by reading the configs and setting things up as required
+function initiatePlugin(config) {
+    var customUrlIframe = document.getElementById('custom-url-iframe');
+    customUrlIframe.setAttribute("src", config.url); 
+
+    if (config.height) {
+      const height = typeof config.height === 'string' ? parseInt(config.height) : config.height;
+      // This sets the height of the outer iframe
+      courseraApi.callMethod({
+        type: 'SET_HEIGHT',
+        data: {
+          height,
+        },
+      });
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  console.log("DOMContentLoaded");
+  if (!courseraApi) {
+    alert('Coursera API not found');
+  }
+  courseraApi.callMethod({
+      type: "GET_SESSION_CONFIGURATION",
+      onSuccess: initiatePlugin,
+      onError: console.log,
+  });
+}); 
+ 

--- a/custom-external-webpage/manifest.json
+++ b/custom-external-webpage/manifest.json
@@ -1,0 +1,28 @@
+{
+  "short_name": "Customized External Webpage (iframe)",
+  "name": "Customized External Webpage (iframe)",
+  "description": "Customized External Webpage (iframe)",
+  "maintainer": {
+    "name": "Example",
+    "email": "example-email@coursera.org"
+  },
+  "version": "0.0.1",
+  "sandbox": "allow-presentation allow-scripts allow-same-origin allow-popups allow-downloads",
+  "authorizations": {},
+  "configurationExamples":[{
+    "configuration": {
+      "url": "https://example.com",
+      "height": "600",
+      "sandbox": "allow-scripts allow-same-origin allow-popups allow-downloads"
+    }
+  }],
+  "actionTypes": ["GET_SESSION_CONFIGURATION", "SET_HEIGHT"],
+  "macros": [],
+  "accessibility": {
+    "mobileCompatibility": {
+      "supportsTouch": true,
+      "minHeightPx": 0,
+      "minWidthPx": 0
+    }
+  }
+}

--- a/custom-external-webpage/style.css
+++ b/custom-external-webpage/style.css
@@ -1,0 +1,21 @@
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0
+}
+
+.container {
+    display: flex;
+    width: 100%;
+    height: 100%;
+}
+
+iframe {
+    border: 0px;
+    outline: 0px;
+    flex-grow: 1;
+    border: none;
+    margin: 0;
+    padding: 0;
+}  


### PR DESCRIPTION
## Summary
This PR adds a new custom plugin example for overriding the sandbox property on a typical external URL iframe plugin, since this question pops up once in a while. It also sets it up so that the custom height configuration is actually used. 

## Test Plan
- Zip the newly added code and upload it via the plugin manager UI
- Use the plugin in a plugin item to test 
